### PR TITLE
fix: LM contracts initialize only once

### DIFF
--- a/contracts/farm/LMV1toLMV2Migrator.sol
+++ b/contracts/farm/LMV1toLMV2Migrator.sol
@@ -61,6 +61,7 @@ contract LMV1toLMV2Migrator is AdminRole {
 		require(address(_SOV) != address(0), "invalid token address");
 		require(address(_liquidityMiningV1) != address(0), "invalid contract address");
 		require(address(_liquidityMiningV2) != address(0), "invalid contract address");
+		require(address(SOV) == address(0), "Already initialized");
 		liquidityMiningV1 = _liquidityMiningV1;
 		liquidityMiningV2 = _liquidityMiningV2;
 		SOV = _SOV;

--- a/contracts/farm/LiquidityMiningV1.sol
+++ b/contracts/farm/LiquidityMiningV1.sol
@@ -36,6 +36,14 @@ contract LiquidityMiningV1 is ILiquidityMiningV1, LiquidityMiningStorageV1 {
 		_;
 	}
 
+	modifier onlyMigrationGracePeriodStarted() {
+		require(
+			migrationGracePeriodState == MigrationGracePeriodStates.Started,
+			"Forbidden: Migration hasn't started yet or already finished"
+		);
+		_;
+	}
+
 	modifier onlyBeforeMigrationGracePeriodFinished() {
 		require(migrationGracePeriodState < MigrationGracePeriodStates.Finished, "Forbidden: contract deprecated");
 		_;
@@ -56,6 +64,7 @@ contract LiquidityMiningV1 is ILiquidityMiningV1, LiquidityMiningStorageV1 {
 	function initialize(address _liquidityMiningV2) external onlyAuthorized {
 		/// @dev Non-idempotent function. Must be called just once.
 		require(_liquidityMiningV2 != address(0), "Invalid address");
+		require(liquidityMiningV2 == address(0), "Already initialized");
 		liquidityMiningV2 = _liquidityMiningV2;
 	}
 
@@ -107,8 +116,7 @@ contract LiquidityMiningV1 is ILiquidityMiningV1, LiquidityMiningStorageV1 {
 	// TODO: this should only be used by the LiquidityMiningV2 contract??
 	/// @notice This function finishes the migration process disabling further withdrawals and claims
 	/// @dev migration grace period should have started before this function is called.
-	function finishMigrationGracePeriod() external onlyAuthorized onlyBeforeMigrationGracePeriodFinished {
-		require(migrationGracePeriodState == MigrationGracePeriodStates.Started, "Migration hasn't started yet");
+	function finishMigrationGracePeriod() external onlyAuthorized onlyMigrationGracePeriodStarted {
 		migrationGracePeriodState = MigrationGracePeriodStates.Finished;
 	}
 

--- a/contracts/farm/LiquidityMiningV2.sol
+++ b/contracts/farm/LiquidityMiningV2.sol
@@ -60,14 +60,10 @@ contract LiquidityMiningV2 is ILiquidityMiningV2, LiquidityMiningStorageV2 {
 	/**
 	 * @notice Initialize mining.
 	 */
-	function initialize(
-		address _wrapper,
-		address _migrator,
-		IERC20 _SOV
-	) external onlyAuthorized {
+	function initialize(address _wrapper, address _migrator) external onlyAuthorized {
 		/// @dev Non-idempotent function. Must be called just once.
 		require(_migrator != address(0), "invalid contract address");
-		require(address(_SOV) != address(0), "invalid token address");
+		require(migrator == address(0), "Already initialized");
 		wrapper = _wrapper;
 		migrator = _migrator;
 	}

--- a/scripts/contractInteraction/liquidity_mining_V1toV2_migrator.py
+++ b/scripts/contractInteraction/liquidity_mining_V1toV2_migrator.py
@@ -16,7 +16,7 @@ def initializeLiquidityMiningV2():
     wrapper = "0x0000000000000000000000000000000000000000"
     liquidityMiningV2 = Contract.from_abi("LiquidityMiningV2", address = conf.contracts['LiquidityMiningProxyV2'], abi = LiquidityMiningV2.abi, owner = conf.acct)
 
-    data = liquidityMiningV2.initialize.encode_input(wrapper,conf.contracts['LMV1toLMV2Migrator'],conf.contracts['SOV'])
+    data = liquidityMiningV2.initialize.encode_input(wrapper,conf.contracts['LMV1toLMV2Migrator'])
     sendWithMultisig(conf.contracts['multisig'], liquidityMiningV2.address, data, conf.acct)
 
 def setMigratorAsAdmin():

--- a/tests/farm/LiquidityMiningV2.js
+++ b/tests/farm/LiquidityMiningV2.js
@@ -75,7 +75,7 @@ describe("LiquidityMiningV2", () => {
 		migrator = await Migrator.new();
 		await migrator.initialize(SOVToken.address, liquidityMiningV1.address, liquidityMining.address);
 
-		await liquidityMining.initialize(wrapper.address, migrator.address, SOVToken.address);
+		await liquidityMining.initialize(wrapper.address, migrator.address);
 
 		erc20RewardTransferLogic = await ERC20TransferLogic.new();
 
@@ -101,20 +101,18 @@ describe("LiquidityMiningV2", () => {
 	describe("initialize", () => {
 		it("should fail if migrator address is invalid", async () => {
 			await deployLiquidityMiningV2();
-			await expectRevert(liquidityMining.initialize(wrapper.address, ZERO_ADDRESS, SOVToken.address), "invalid contract address");
+			await expectRevert(liquidityMining.initialize(wrapper.address, ZERO_ADDRESS), "invalid contract address");
 		});
 
-		it("should fail if SOV address is invalid", async () => {
+		it("fails if already initialized", async () => {
 			await deployLiquidityMiningV2();
-			await expectRevert(
-				liquidityMining.initialize(wrapper.address, liquidityMiningV1.address, ZERO_ADDRESS),
-				"invalid token address"
-			);
+			await liquidityMining.initialize(wrapper.address, liquidityMiningV1.address);
+			await expectRevert(liquidityMining.initialize(wrapper.address, liquidityMiningV1.address), "Already initialized");
 		});
 
 		it("sets the expected values", async () => {
 			await deployLiquidityMiningV2();
-			await liquidityMining.initialize(wrapper.address, liquidityMiningV1.address, SOVToken.address);
+			await liquidityMining.initialize(wrapper.address, liquidityMiningV1.address);
 
 			let _wrapper = await liquidityMining.wrapper();
 
@@ -569,7 +567,7 @@ describe("LiquidityMiningV2", () => {
 		});
 		it("should only allow to deposit if migration is finished", async () => {
 			await deployLiquidityMiningV2();
-			await liquidityMining.initialize(wrapper.address, liquidityMiningV1.address, SOVToken.address);
+			await liquidityMining.initialize(wrapper.address, liquidityMiningV1.address);
 			await liquidityMining.addRewardToken(SOVToken.address, rewardTokensPerBlock, startDelayBlocks, rewardTransferLogic.address);
 
 			await expectRevert(
@@ -1540,7 +1538,7 @@ describe("LiquidityMiningV2", () => {
 			migrator = await Migrator.new();
 			await migrator.initialize(SOVToken.address, liquidityMiningV1.address, liquidityMining.address);
 
-			await liquidityMining.initialize(wrapper.address, migrator.address, SOVToken.address);
+			await liquidityMining.initialize(wrapper.address, migrator.address);
 
 			for (let token of [token1, token2]) {
 				for (let account of [account1, account2]) {

--- a/tests/loan-token/LendingWithLMV2.test.js
+++ b/tests/loan-token/LendingWithLMV2.test.js
@@ -97,7 +97,7 @@ contract("LoanTokenLogicLM", (accounts) => {
 		migrator = await Migrator.new();
 		await migrator.initialize(SOVToken.address, liquidityMiningV1.address, liquidityMining.address);
 
-		await liquidityMining.initialize(wrapper.address, migrator.address, SOVToken.address);
+		await liquidityMining.initialize(wrapper.address, migrator.address);
 
 		rewardTransferLogic = await LockedSOVRewardTransferLogic.new();
 		await rewardTransferLogic.initialize(lockedSOV.address, unlockedImmediatelyPercent);


### PR DESCRIPTION
- LiquidityMiningV1, LiquidityMiningV2 and Migrator can be initialized only once
- Add onlyMigrationGracePeriodStarted modifier in LiquidityMiningV1
- Remove unused SOV address from LiquidityMiningV2 